### PR TITLE
fix: expand globs

### DIFF
--- a/features/steps/local.py
+++ b/features/steps/local.py
@@ -32,7 +32,7 @@ def step_impl(
     with open(os.path.join(leaf_dir1, "file.txt"), "w", encoding="utf-8") as f:
         f.write("Rogue")
     with open(os.path.join(leaf_dir2, "file.txt"), "w", encoding="utf-8") as f:
-        f.write("Serenity")
+        f.write("{{Serenity}}")
 
     yaml_data = {
         "templates": [

--- a/features/update/local.feature
+++ b/features/update/local.feature
@@ -43,7 +43,6 @@ Feature: Local Template Processing
     When I run stenciler update in the current directory
     Then I see the current directory updated with the template data
 
-  @wip
   Scenario: Init only files are not copied during an update
     Given I have a local updated template with init-only files
     When I run stenciler update in the current directory

--- a/files/template.go
+++ b/files/template.go
@@ -31,7 +31,13 @@ func CopyTemplated(repoDir string, tmplate *config.Template) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate file list: %w", err)
 	}
-	fileList = removeFromFileList(fileList, tmplate.RawCopyPaths)
+
+	rawList, err := createFileList(srcRootPath, tmplate.RawCopyPaths)
+	if err != nil {
+		return fmt.Errorf("failed to generate raw copy file list: %w", err)
+	}
+
+	fileList = removeFromFileList(fileList, rawList)
 
 	if tmplate.Update {
 		initOnlyList, err := createFileList(srcRootPath, tmplate.InitOnlyPaths)


### PR DESCRIPTION
expand raw copy globs when removing files from templated file list