### PR TITLE
build: bump Go version to 1.26

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -7,7 +7,7 @@
     "features": {
         "ghcr.io/devcontainers-extra/features/poetry:2": {},
         "ghcr.io/devcontainers/features/go:1": {
-            "version": "1.24",
+            "version": "1.26",
             "golangciLintVersion": "2.1.6"
         }
     },

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -8,7 +8,7 @@
         "ghcr.io/devcontainers-extra/features/poetry:2": {},
         "ghcr.io/devcontainers/features/go:1": {
             "version": "1.26",
-            "golangciLintVersion": "2.1.6"
+            "golangciLintVersion": "2.12.2"
         }
     },
     "customizations": {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 env:
   GO_VERSION: 1.26
   PY_VERSION: 3.12
-  GOLANGCI_LINT_VERSION: v2.1.6
+  GOLANGCI_LINT_VERSION: v2.12.2
 
 jobs:
   lint-commit:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  GO_VERSION: 1.24
+  GO_VERSION: 1.26
   PY_VERSION: 3.12
   GOLANGCI_LINT_VERSION: v2.1.6
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 env:
-  GO_VERSION: 1.24
+  GO_VERSION: 1.26
 
 permissions:
   contents: write

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/rogueserenity/stenciler
 
-go 1.24.0
-
-toolchain go1.24.7
+go 1.26.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0


### PR DESCRIPTION
## Summary

- Updates Go version from 1.24 to 1.26 in `go.mod`, CI workflow, release workflow, and devcontainer
- Removes the `toolchain` directive (no longer needed when the `go` directive matches the installed version)
- Unblocks dependabot PR #144, which bumps `go-git/go-git` to v5.19.0 (security fix) but requires Go >= 1.25

## Test plan

- [ ] CI passes with Go 1.26
- [ ] Merge this, then rebase/merge PR #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)